### PR TITLE
Fixed Heapify.py

### DIFF
--- a/Week_8/Heapify.py
+++ b/Week_8/Heapify.py
@@ -12,18 +12,20 @@ https://seneca-ictoer.github.io/data-structures-and-algorithms/I-Heaps/heap-sort
 def heapify(a_node):
     '''Creates a max heapified version of a binary tree.'''
     if a_node.children:
+        
+        # Heapify all the children  
+        for child in a_node.children:
+            heapify(child)
+        
         largest_child = (max(a_node.children, key=lambda n: n.data))
         largest = (largest_child if largest_child.data > a_node.data else a_node)
 
         # If largest is not root, swap and continue heapifying
         if largest != a_node:
             # Swap data only, want to keep structure the same
-            heapify(largest) # Sift it to the top
             a_node.data, largest.data = largest.data, a_node.data
+            heapify(largest) # Ensure the heap property is kept for the sub-tree
 
-        # Ensure all children are heapified as well
-        for child in a_node.children:
-            heapify(child)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Heapify the children first and then swap the data -> then heapify to maintain the heap property. If we don't heapify the children first, then if the original root is bigger than its 2 children, it'll never swap

EX.
4 
 - 2 
     -  1 
     - 10
 - 3
     - 7

Old heapify would result in 
4 
 - 2 
     - 1
 - 10
     - 7
     - 3

but we wanted
10
 - 2
     - 1
 - 7
    - 4
    - 3

because largest_child would choose between 2 and 3 since the subtrees weren't heapified, but since we heapify the subtrees first, largest_child is between 2 and 10 and then can swap properly and then heapify the subtree which swapped.